### PR TITLE
[minecraft-discordapp1] BugFix: except occurred in discord embed color is green #42

### DIFF
--- a/minecraft-discordapp1/main.py
+++ b/minecraft-discordapp1/main.py
@@ -49,9 +49,7 @@ logger.info('Init')
 import os,sys
 import traceback
 import discord
-import json
 import datetime
-import math
 from dotenv import load_dotenv
 from mcrcon import MCRcon
 


### PR DESCRIPTION
[[minecraft-discordapp1] except occurred in discord embed color is green #42](https://github.com/n138-kz/Dockerfile.minecraft/issues/42)

```sh
git pull; docker compose down minecraft-discordapp1 -t 1; docker compose build minecraft-discordapp1; docker compose up -d minecraft-discordapp1
```
